### PR TITLE
Getopts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ It is crucial that the chromosome names in the `info_file.csv` match those in `g
 
 The pipeline can be run using the following command: 
 ```
-./crispr.sh sample_name info_file.csv true/false genome.fasta fastqDir outDir
+./crispr.sh -s sample_name -i info_file.csv -m true/false -g genome.fasta -f fastqDir -o outDir
 ```
 
 ## Parameter definitions
-* **sample_name** is the sample name
-* **info_file.csv** contains information about the guide sequence (see above)
-* **true/false** indicates whether the mapping step should be executed
-* **genome.fa** is the full path to the genome file (bwa and fai index files need to be in the same directory)
-* **fastqDir** is the directory with the fastq files
-* **outDir** is the directory for the results
+* **-s** is the sample name
+* **-i** contains information about the guide sequence (see above)
+* **-m** indicates whether the mapping step should be executed
+* **-g** is the full path to the genome file (bwa and fai index files need to be in the same directory)
+* **-f** is the directory with the fastq files
+* **-o** is the directory for the results

--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ The pipeline can be run using the following command:
 ```
 
 ## Parameter definitions
-* **-s** is the sample name
-* **-i** contains information about the guide sequence (see above)
-* **-m** indicates whether the mapping step should be executed
-* **-g** is the full path to the genome file (bwa and fai index files need to be in the same directory)
-* **-f** is the directory with the fastq files
-* **-o** is the directory for the results
+**-s** 
+: is the sample name
+**-i** 
+: contains information about the guide sequence (see above)
+**-m** 
+: indicates whether the mapping step should be executed
+**-g** 
+: is the full path to the genome file (bwa and fai index files need to be in the same directory)
+**-f** 
+: is the directory with the fastq files
+**-o** 
+: is the directory for the results

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Analysis of MiSeq amplicon data from CRISPR experiments.
 
 ## Prerequisites 
 
-This pipeline utilises [BWA](http://bio-bwa.sourceforge.net/) to map short paired-end amplicon data to a genome sequence. After postprocessing with [samtools](http://samtools.sourceforge.net/), the data is further analysed using the [CrispRVariants](https://bioconductor.org/packages/release/bioc/html/CrispRVariants.html) R package . In addition to CrispRVariants, the following R packages need to be installed:
+This pipeline utilises [BWA](http://bio-bwa.sourceforge.net/) to map short paired-end amplicon data to a genome sequence. After postprocessing with [samtools](http://samtools.sourceforge.net/), the data is further analysed using the [CrispRVariants](https://bioconductor.org/packages/release/bioc/html/CrispRVariants.html) R package. In addition to CrispRVariants, the following R packages need to be installed:
 
 * rtracklayer
 * Biostrings
@@ -22,14 +22,14 @@ It is crucial that the chromosome names in the `info_file.csv` match those in `g
 
 The pipeline can be run using the following command: 
 ```sh
-./crispr.sh -s sample_name -i info_file.csv -m true/false -g genome.fasta -f fastqDir -o outDir
+./crispr.sh -s sample_name -i info_file.csv -m -g genome.fasta -f fastqDir -o outDir
 ```
 
 ## Parameter definitions
 ```
 -s	is the sample name
 -i	contains information about the guide sequence (see above)
--m	indicates whether the mapping step should be executed
+-m	is a flag indicating whether the mapping step should be executed (omit if you don't want to map)
 -g	is the full path to the genome file (bwa and fai index files need to be in the same directory)
 -f	is the directory with the fastq files
 -o	is the directory for the results

--- a/README.md
+++ b/README.md
@@ -21,22 +21,22 @@ It is crucial that the chromosome names in the `info_file.csv` match those in `g
 ## Execution
 
 The pipeline can be run using the following command: 
-```
+```sh
 ./crispr.sh -s sample_name -i info_file.csv -m true/false -g genome.fasta -f fastqDir -o outDir
 ```
 
 ## Parameter definitions
 ```
 -s
-is the sample name
+	is the sample name
 -i
-contains information about the guide sequence (see above)
+	contains information about the guide sequence (see above)
 -m 
-indicates whether the mapping step should be executed
+	indicates whether the mapping step should be executed
 -g 
-is the full path to the genome file (bwa and fai index files need to be in the same directory)
+	is the full path to the genome file (bwa and fai index files need to be in the same directory)
 -f 
-is the directory with the fastq files
+	is the directory with the fastq files
 -o 
-is the directory for the results
+	is the directory for the results
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The pipeline can be run using the following command:
 ```
 
 ## Parameter definitions
-**-s** 	is the sample name
-**-i** 	contains information about the guide sequence (see above)
-**-m** 	indicates whether the mapping step should be executed
-**-g** 	is the full path to the genome file (bwa and fai index files need to be in the same directory)
-**-f** 	is the directory with the fastq files
-**-o** 	is the directory for the results
+* **-s** is the sample name
+* **-i** contains information about the guide sequence (see above)
+* **-m** indicates whether the mapping step should be executed
+* **-g** is the full path to the genome file (bwa and fai index files need to be in the same directory)
+* **-f** is the directory with the fastq files
+* **-o** is the directory for the results

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ The pipeline can be run using the following command:
 
 ## Parameter definitions
 **-s** 
-: is the sample name
+is the sample name
 **-i** 
-: contains information about the guide sequence (see above)
+contains information about the guide sequence (see above)
 **-m** 
-: indicates whether the mapping step should be executed
+indicates whether the mapping step should be executed
 **-g** 
-: is the full path to the genome file (bwa and fai index files need to be in the same directory)
+is the full path to the genome file (bwa and fai index files need to be in the same directory)
 **-f** 
-: is the directory with the fastq files
+is the directory with the fastq files
 **-o** 
-: is the directory for the results
+is the directory for the results

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The pipeline can be run using the following command:
 ```
 
 ## Parameter definitions
-* **-s** is the sample name
-* **-i** contains information about the guide sequence (see above)
-* **-m** indicates whether the mapping step should be executed
-* **-g** is the full path to the genome file (bwa and fai index files need to be in the same directory)
-* **-f** is the directory with the fastq files
-* **-o** is the directory for the results
+**-s** 	is the sample name
+**-i** 	contains information about the guide sequence (see above)
+**-m** 	indicates whether the mapping step should be executed
+**-g** 	is the full path to the genome file (bwa and fai index files need to be in the same directory)
+**-f** 	is the directory with the fastq files
+**-o** 	is the directory for the results

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Analysis of MiSeq amplicon data from CRISPR experiments.
 
 ## Prerequisites 
 
-This pipeline utilises BWA (http://bio-bwa.sourceforge.net/) to map short paired-end amplicon data to a genome sequence. After postprocessing with samtools (http://samtools.sourceforge.net/), the data is further analysed using the CrispRVariants R package (https://bioconductor.org/packages/release/bioc/html/CrispRVariants.html). In addition to CrispRVariants, the following R packages need to be installed:
+This pipeline utilises [BWA](http://bio-bwa.sourceforge.net/) to map short paired-end amplicon data to a genome sequence. After postprocessing with [samtools](http://samtools.sourceforge.net/), the data is further analysed using the [CrispRVariants](https://bioconductor.org/packages/release/bioc/html/CrispRVariants.html) R package . In addition to CrispRVariants, the following R packages need to be installed:
 
 * rtracklayer
 * Biostrings

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ The pipeline can be run using the following command:
 
 ## Parameter definitions
 ```
-**-s** 
+-s
 is the sample name
-**-i** 
+-i
 contains information about the guide sequence (see above)
-**-m** 
+-m 
 indicates whether the mapping step should be executed
-**-g** 
+-g 
 is the full path to the genome file (bwa and fai index files need to be in the same directory)
-**-f** 
+-f 
 is the directory with the fastq files
-**-o** 
+-o 
 is the directory for the results
 ```

--- a/README.md
+++ b/README.md
@@ -27,16 +27,10 @@ The pipeline can be run using the following command:
 
 ## Parameter definitions
 ```
--s
-	is the sample name
--i
-	contains information about the guide sequence (see above)
--m 
-	indicates whether the mapping step should be executed
--g 
-	is the full path to the genome file (bwa and fai index files need to be in the same directory)
--f 
-	is the directory with the fastq files
--o 
-	is the directory for the results
+-s	is the sample name
+-i	contains information about the guide sequence (see above)
+-m	indicates whether the mapping step should be executed
+-g	is the full path to the genome file (bwa and fai index files need to be in the same directory)
+-f	is the directory with the fastq files
+-o	is the directory for the results
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The pipeline can be run using the following command:
 ```
 
 ## Parameter definitions
+```
 **-s** 
 is the sample name
 **-i** 
@@ -38,3 +39,4 @@ is the full path to the genome file (bwa and fai index files need to be in the s
 is the directory with the fastq files
 **-o** 
 is the directory for the results
+```

--- a/crispr.sh
+++ b/crispr.sh
@@ -1,23 +1,36 @@
 #!/bin/bash
 
-# example execution: ./crispr.sh A15 info_file.csv true genome.fasta fastqDir outDir
+# example execution: ./crispr.sh -s A15 -i info_file.csv -m true -g genome.fasta -f fastqDir -o outDir
 # where:
-# 'A15' is the sample name
-# 'info_file.csv' contains information about the guide sequence
-# 'true/false' indicates whether the mapping step should be executed
-# 'genome.fasta' is the full path to the genome file (bwa and fai index files need to be in the same directory)
-# 'fastqDir' is the directory with the fastq files
-# 'outDir' is the directory for the results
+# -s is the sample name
+# -i contains information about the guide sequence
+# -m indicates whether the mapping step should be executed
+# -g is the full path to the genome file (bwa and fai index files need to be in the same directory)
+# -f is the directory with the fastq files
+# -o is the directory for the results
 
 
 # variable definitions from command line parameters
 
-sample=$1
-infoFile=$2
-map=$3
-genome=$4
-fastqDir=$5
-outDir=$6
+while getopts ":s:i:m:g:f:o:" opt; do
+	case $opt in
+		s) sample="$OPTARG"
+		;;
+		i) infoFile="$OPTARG"
+		;;
+		m) map="$OPTARG"
+		;;
+		g) genome="$OPTARG"
+		;;
+		f) fastqDir="$OPTARG"
+		;;
+		o) outDir="$OPTARG"
+		;;
+		\?) echo "Invalid option -$OPTARG" >&2
+		;;
+		:) echo "Option -$OPTARG requires an argument." >&2
+	esac
+done
 
 # only run mapping stage if 'map' variable is set to true
 # explanation: usually, the read mapping only has to be done once

--- a/crispr.sh
+++ b/crispr.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# example execution: ./crispr.sh -s A15 -i info_file.csv -m true -g genome.fasta -f fastqDir -o outDir
+# example execution: ./crispr.sh -s A15 -i info_file.csv -m -g genome.fasta -f fastqDir -o outDir
 # where:
 # -s is the sample name
 # -i contains information about the guide sequence
-# -m indicates whether the mapping step should be executed
+# -m indicates whether the mapping step should be executed (omit if you don't want to map)
 # -g is the full path to the genome file (bwa and fai index files need to be in the same directory)
 # -f is the directory with the fastq files
 # -o is the directory for the results
@@ -12,13 +12,16 @@
 
 # variable definitions from command line parameters
 
-while getopts ":s:i:m:g:f:o:" opt; do
+# default for mapping option unless -m flag is set
+map=false
+
+while getopts ":s:i:mg:f:o:" opt; do
 	case $opt in
 		s) sample="$OPTARG"
 		;;
 		i) infoFile="$OPTARG"
 		;;
-		m) map="$OPTARG"
+		m) map=true
 		;;
 		g) genome="$OPTARG"
 		;;


### PR DESCRIPTION
The way that parameters are provided to the `crispr.sh` script has been changed. They are now indicated with single-letter flags to allow a random order of providing them. Additionally, the `map` parameter is a simple flag without any arguments. This is implemented with `getopts`. Some smaller formatting changes have also been made. 